### PR TITLE
feat: add stable/removal-acking action

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,21 @@
+# Contributing
+
+## Explantions
+
+We do our best to follows [Diataxis Documentation Framework](https://diataxis.fr/).
+
+## How-Tos
+
+###  Release a new version of an action
+
+1. Verify the `CHANGELOG.md` file is up-to-date.
+2. Create a [New Release](https://github.com/erlef/gh-actions/releases/new)
+    1. The "Tag" and "Release title" **MUST** be match the following pattern:
+
+      ```text
+      <Launch Stage>/<Actio Name>@v<SemVer>
+      ```
+
+      Eg: `stable/removal-acking@v1.0.0`
+
+    2. The SemVer **MUST** match the latest version in the `CHANGELOG.md` file.

--- a/README.md
+++ b/README.md
@@ -14,12 +14,16 @@ libraries.
 
 ## References
 
+- [Contributing](./CONTRIBUTING.md) Guide.
+
 ## Explanations
 
 ### Launch Stage
 
 - **Preview:** Actions are for testing. No guarantees are provided of any kind.
-  You can find them in the `./preview` directory.
+  You can find them in the `./preview` directory. Expect breaking changes and
+  bugs. The intention is to gather feedback and iterate on the design.
 
 - **Stable:** Actions are for production usage. They are supported and
-  maintained. You can find them in the `./stable` directory.
+  maintained. You can find them in the `./stable` directory. Expect proper
+  SemVer versioning and changelogs.

--- a/stable/removal-acking/CHANGELOG.md
+++ b/stable/removal-acking/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## v0.1.0
+
+- Initial release

--- a/stable/removal-acking/README.md
+++ b/stable/removal-acking/README.md
@@ -1,0 +1,3 @@
+# erlef/gh-actions/stable/removal-acking
+
+Requires a user to acknowledge the removal of a given Action.

--- a/stable/removal-acking/action.yaml
+++ b/stable/removal-acking/action.yaml
@@ -1,0 +1,51 @@
+name: Removal Acknowledgement
+description: >-
+  Used to verify the user's acknowledgement of the removal of the action in the
+  future. This action is used to ensure that the user is aware of the removal of
+  the action and the reason for the removal.
+author: Erlang Ecosystem Foundation
+branding:
+  color: red
+  icon: alert-triangle
+
+inputs:
+  action-name:
+    description: The name of the action.
+    required: true
+  requires-ack:
+    description: The action requires acknowledgement.
+    required: false
+    default: "false"
+  user-ack:
+    description: The user acknowledges of the removal of the action in the future.
+    required: true
+    default: "false"
+  removal-date:
+    description: The date the action will be removed.
+    required: false
+    default: "No date provided."
+  removal-reason:
+    description: The reason for the removal of the action.
+    required: false
+    default: "No reason provided."
+
+runs:
+  using: composite
+  steps:
+    - name: Verify the User Acknowledgement
+      if: "${{ inputs.requires-ack == 'true' }}"
+      shell: bash
+      run: |
+        if [ "${{ inputs.user-ack }}" != "true" ]; then
+          echo "# Removal Acknowledgement Required" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- **Removal Date:** ${{ inputs.removal-date }}." >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "${{ inputs.action-name }} action will be removed on the specified date. You must acknowledge the removal of the action." >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "## Reason" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "${{ inputs.removal-reason }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          exit 1
+        fi


### PR DESCRIPTION
This action is a foundation for a ready-to-go action to maintain the other actions properly. We do our best to inform the users about potential removal or migration from `preview` to `stable.`

![Screenshot 2024-06-24 at 1 20 04 AM](https://github.com/erlef/gh-actions/assets/4237280/a5bf59a0-e391-40bf-acd9-ef0d435060fd)
